### PR TITLE
Richiesta aggiunta download epub e pdf su readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.13"
 sphinx:
   configuration: tutorial/source/conf.py
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,3 +7,7 @@ build:
     python: "3.11"
 sphinx:
   configuration: tutorial/source/conf.py
+
+formats:
+  - epub
+  - pdf


### PR DESCRIPTION
Scusa il disturbo, puoi aggiungere il supporto al download direttamente in formato epub e pdf?
Ci sono impazzito per capire che non era stato attivato.
Buone vacanze a tutti.